### PR TITLE
Only report significant GetCrc32FromFile file progression events

### DIFF
--- a/src/Misc/Crc32Utils.cs
+++ b/src/Misc/Crc32Utils.cs
@@ -54,6 +54,8 @@ namespace ProjectCeleste.GameFiles.Tools.Misc
                     int read;
                     var totalread = 0L;
                     var length = fs.Length;
+                    var lastProgress = 0d;
+
                     while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
                     {
                         //
@@ -63,7 +65,13 @@ namespace ProjectCeleste.GameFiles.Tools.Misc
 
                         result = Crc32Algorithm.Append(result, buffer, 0, read);
 
-                        progress?.Report((double) totalread / length * 100);
+                        var newProgress = (double)totalread / length * 100;
+
+                        if (newProgress - lastProgress > 1)
+                        {
+                            progress?.Report(newProgress);
+                            lastProgress = newProgress;
+                        }
 
                         if (totalread >= length)
                             break;


### PR DESCRIPTION
# Description
When verifying file checksums, the UI will become unresponsive since the progress object will be spammed with tiny file operations. Instead, we only report progression events when the progress is over 1%.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings